### PR TITLE
Add initial files to repo, including the list of TSC members

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Hyperledger Code of Conduct
+
+Hyperledger Indy requires adherence to the [Hyperledger Code of Conduct](https://wiki.hyperledger.org/display/HYP/Hyperledger+Code+of+Conduct). All Working Group contributors and meeting attendees are asked
+to review and follow the code of conduct.
+
+![Hyperledger Code of Conduct, Everyone is Welcome](https://wiki.hyperledger.org/download/attachments/2392771/welcome.png?version=2&modificationDate=1572450107000&api=v2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# How to contribute
+
+You are encouraged to contribute to the repository by **forking and submitting a pull request**.
+
+For significant changes, please open an issue first to discuss the proposed changes to avoid re-work.
+
+(If you are new to GitHub, you might start with a [basic tutorial](https://help.github.com/articles/set-up-git) and check out a more detailed guide to [pull requests](https://help.github.com/articles/using-pull-requests/).)
+
+Pull requests will be evaluated by the repository guardians on a schedule and if deemed beneficial will be committed to the master. Pull requests should have a descriptive name and include an summary of all changes made in the pull request description.
+
+If you would like to propose a significant change, please open an issue first to discuss the work with the community.
+
+All contributors retain the original copyright to their stuff, but by contributing to this project, you grant a world-wide, royalty-free, perpetual, irrevocable, non-exclusive, transferable license to all users **under the terms of the license under which this project is distributed.**

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,89 @@
+# Maintainers
+
+This file defines the Maintainers processes (adding, removing) and duties for all repositories in the Hyperledger Indy Project,
+as well as the list of Maintainers for this repository. "Maintainers" are defined as any individuals with escalated GitHub privileges above
+"READ" in Hyperledger Indy repositories. Maintainers **MUST** abide by the Hyperledger Indy Project Charter.
+
+All other Hyperledger Indy Project repository MAINTAINERS.md files point to this file.
+
+## Maintainers for this Repository
+
+Maintainers for this repository are listed in the [Access Control YAML file].
+Search in the file for this repository.
+
+[Access Control YAML file]: https://github.com/hyperledger/governance/blob/main/access-control.yaml
+
+## The Duties of a Hyperledger Indy Maintainers
+
+Maintainers are expected to fulfill the following responsibilities for the repositories they oversee. The duties are listed in more or less priority order:
+
+- Review, respond, and act on any security vulnerabilities reported against the repository.
+- Review, provide feedback on, and merge or reject GitHub Pull Requests from
+  Contributors.
+- Review, triage, comment on, and close GitHub Issues
+  submitted by Contributors.
+- When appropriate, lead/facilitate architectural discussions in the community.
+- When appropriate, lead/facilitate the creation of a product roadmap.
+- Create, clarify, and label issues to be worked on by Contributors.
+- Ensure that there is a well defined (and ideally automated) product test and
+  release pipeline, including the publication of release artifacts.
+- When appropriate, execute the product release process.
+- Maintain the repository CONTRIBUTING.md file and getting started documents to
+  give guidance and encouragement to those wanting to contribute to the product, and those wanting to become maintainers.
+- Contribute to the product via GitHub Pull Requests.
+- Monitor requests from the Hyperledger Technical Oversight Committee about the
+contents and management of Hyperledger repositories, such as branch handling,
+required files in repositories and so on.
+- Contribute to the Hyperledger Project's Quarterly Report.
+
+## Becoming a Hyperledger Indy Maintainer
+
+This community welcomes contributions. Interested contributors are encouraged to
+progress to become maintainers. To become a maintainer the following steps
+occur, roughly in order.
+
+- The proposed maintainer establishes their reputation in the community,
+  including authoring five (5) significant merged pull requests, and expresses
+  an interest in becoming a maintainer for the repository.
+- A PR is created to update the [Access Control YAML file] to add the proposed maintainer on team with appropriate privileges in the relevant repositories.
+- The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
+- The PR is authored by the proposed maintainer or has a comment on the PR from the proposed maintainer confirming their interest in being a maintainer.
+  - The PR or comment from the proposed maintainer must include their
+    willingness to be a long-term (more than 6 month) maintainer.
+- Once the PR and necessary comments have been received, an approval time frame begins.
+- The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
+- The PR is merged and the proposed maintainer becomes a maintainer if either:
+  - At least three (3) TSC or project Maintainers approve the PR or provide an approval comment on the PR.
+- If the PR does not get the requisite PR approvals, it may be closed.
+
+## Removing Hyperledger Indy Maintainers
+
+Being a maintainer is not a status symbol or a title to be carried
+indefinitely. It will occasionally be necessary and appropriate to move a
+maintainer to emeritus status. This can occur in the following situations:
+
+- Resignation of a maintainer.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be no commits or code review comments
+    for one reporting quarter. This will not be strictly enforced if
+    the maintainer expresses a reasonable intent to continue contributing.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other circumstances at the discretion of the other Maintainers.
+
+The process to remove a maintainer from active status is comparable to the process for adding a maintainer, outlined above. In the case of voluntary
+resignation, the Pull Request can be merged following a maintainer PR approval. If the removal is for any other reason, the following steps **SHOULD** be followed:
+
+- A PR is created to update the [Access Control YAML file] to remove the maintainer from the appropriate teams.
+- The PR is authored by, or has a comment supporting the proposal from, an existing maintainer or Hyperledger GitHub organization administrator.
+- Once the PR and necessary comments have been received, the approval timeframe begins.
+- The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
+- The PR is merged and the maintainer is removed if:
+  - The PR is approved by the maintainer to be removed, OR
+  - At least three (3) TSC or Indy Project maintainer PR approvals or approval comments have been recorded.
+- If the PR does not get the requisite PR approvals, it may be closed.
+
+Returning to active maintainer status after being removed uses the same steps as adding a
+new maintainer. Note that the emeritus maintainer already has the 5 required
+significant changes as there is no contribution time horizon for those.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Hyperledger Indy
+
+![Indy Logo](https://raw.githubusercontent.com/hyperledger/indy-node/main/collateral/logos/indy-logo.png)
+
+Hyperledger Indy is an open source implementation of a distributed ledger,
+purpose-built for identity solutions using privacy preserving verifiable
+credentials.
+
+If you are a developer, begin your journey by looking at an Aries Framework that
+interact with Indy, such as [Aries Cloud Agent Python](https://aca-py.org),
+[Credo TS](https://github.com/openwallet-foundation/credo-ts) or [Aries
+VCX](https://github.com/hyperledger/aries-vcx)
+
+## Key Characteristics
+
+Distributed ledger purpose-built for decentralized identity
+
+- Correlation-resistant by design
+- DIDs (Decentralized Identifiers) that are globally unique and resolvable (via
+  a ledger) without requiring any centralized resolution authority
+- Pairwise Identifiers create secure, 1:1 relationships between any two entities
+- Verifiable Claims are interoperable format for exchange of digital identity
+  attributes and relationships currently in the standardization pipeline at the
+  W3C
+- Zero Knowledge Proofs which prove that some or all of the data in a set of
+  Claims is true without revealing any additional information, including the
+  identity of the Prover

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,172 @@
+# Hyperledger Indy Security Policy
+
+[Hyperledger security vulnerability disclosure policy]: /governing-documents/security.md
+
+## About this document
+
+This document defines how security vulnerability reporting is handled in the
+Hyperledger Indy project. The approach aligns with the [Hyperledger
+Foundation's Security Vulnerability Reporting
+policy](https://toc.hyperledger.org/governing-documents/security.html). Please
+review that document to understand the basis of the security reporting for
+Hyperledger Indy.
+
+The Hyperledger Security Vulnerability policy borrows heavily from the
+recommendations of the OpenSSF Vulnerability Disclosure working group. For
+up-to-date information on the latest recommendations related to vulnerability
+disclosures, please visit the [GitHub of that working
+group](https://github.com/ossf/wg-vulnerability-disclosures).
+
+If you are already familiar with the security policies of Hyperledger Indy, and
+ready to report a vulnerability, please jump to [Report
+Intakes](#report-intakes).
+
+## Outline
+
+This document has the following sections:
+
+- [Hyperledger Indy Security Policy](#hyperledger-indy-security-policy)
+  - [About this document](#about-this-document)
+  - [Outline](#outline)
+  - [What Is a Vulnerability Disclosure Policy?](#what-is-a-vulnerability-disclosure-policy)
+  - [Security Team](#security-team)
+  - [Discussion Forums](#discussion-forums)
+  - [Report Intakes](#report-intakes)
+  - [CNA/CVE Reporting](#cnacve-reporting)
+  - [Embargo List](#embargo-list)
+  - [(GitHub) Security Advisories](#github-security-advisories)
+  - [Private Patch Deployment Infrastructure](#private-patch-deployment-infrastructure)
+
+## What Is a Vulnerability Disclosure Policy?
+
+No piece of software is perfect. All software (at least, all software of a
+certain size and complexity) has bugs. In open source development, members of
+the community or the public find bugs and report them to the project. A
+vulnerability disclosure policy explains how this process functions from the
+perspective of the project.
+
+This vulnerability disclosure policy explains the rules and guidelines for
+Hyperledger Indy. It is intended to act as both a reference for
+outsiders–including both bug reporters and those looking for information on the
+project's security practices–as well as a set of rules that maintainers and
+contributors have agreed to follow.
+
+## Security Team
+
+The current Hyperledger Indy security team is:
+
+| Name             | Email ID                 | Discord ID      | Area/Specialty         |
+| ---------------- | ------------------------ | --------------- | ---------------------- |
+| Stephen Curran   | swcurran@cloudcompass.ca | swcurran        |              |
+| Wade Barnes      | wade@neoterictech.ca     | WadeBarnes      | Security, Operations   |
+| Sam Curren       | sam@indicio.tech         | TelegramSam     | Security               |
+| Andrew Whitehead | cywolf@gmail.com         | andrewwhitehead | Cryptography, Security |
+
+The security team for Hyperledger Indy must include at least three Indy
+Maintainers that agree to carry out the following duties and responsibilities.
+Members are added and removed from the team via approved Pull Requests to this
+repository. For additional background into the role of the security team, see
+the [People Infrastructure] section of the Hyperledger Security Policy.
+
+[People Infrastructure]: https://toc.hyperledger.org/governing-documents/security.html#people-infrastructure
+
+**Responsibilities:**
+
+1. Acknowledge the receipt of vulnerability reports to the reporter within 2
+   business days.
+
+2. Assess the issue. Engage with the reporter to ask any outstanding questions
+about the report and how to reproduce it. If the report was received by email
+and may be a security vulnerability, open a GitHub Security Advisory on the
+repository to manage the report. If the report is not considered a
+vulnerability, then the reporter should be informed and this process can be
+halted. If the report is a regular bug (but not a security vulnerability), the
+reporter should be informed (if necessary) of the regular process for reporting
+issues.
+
+1. Some issues may require more time and resources to correct. If a particular
+report is complex, discuss an embargo period with the reporter during which
+time the report will not be publicly disclosed. The embargo period should be
+negotiated with the reporter and must not be longer than 90 days.
+
+1. If necessary, create a private patch development infrastructure for the issue
+   by emailing the [Hyperledger Community Architects].
+
+[Hyperledger Community Architects]: mailto:community-architects@hyperledger.org
+
+5. Request a CVE for the issue (see the [CNA/CVE Reporting](#cnacve-reporting)
+   section).
+
+6. Decide a date for the public release of the vulnerability report, the date
+   the embargo period ends.
+
+7. If applicable, notify members of the embargo list of the vulnerability,
+upcoming patch and release, as described above.
+
+8. Publish a new (software) release in which the vulnerability is addressed.
+
+9. Publicly disclose the issue within 48 hours after the release via a
+GitHub security advisory (see the [(GitHub) Security
+Advisories](#github-security-advisories) section for details).
+
+## Discussion Forums
+
+Discussions about each reported vulnerability should be carried out in the
+private GitHub security advisory about the vulnerability. If necessary, a private
+channel specific to the issue may be created on the Hyperledger Discord server
+with invited participants added to the discussion.
+
+## Report Intakes
+
+Hyperledger Indy has the following ways to submit security
+vulnerabilities. While the security team members will do their best to
+respond to bugs disclosed in all possible ways, it is encouraged for bug
+finders to report through the following approved channels:
+
+- Email the [Hyperledger Foundation security
+list](mailto:security@lists.hyperledger.org): To report a security issue, please
+send an email with the name of the project/repository, a description of the issue, the
+steps you took to create the issue, affected versions, and if known,
+mitigations. If in triaging the email, the security team determines the issue may be
+a security vulnerability, a [GitHub security vulnerability report] will be
+opened.
+- Open a [GitHub security vulnerability report]: Open a draft security advisory
+on the "Security" tab of this GitHub repository. See [GitHub Security
+Advisories](#github-security-advisories) to learn more about the security
+infrastructure in GitHub.
+
+[GitHub security vulnerability report]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+
+## CNA/CVE Reporting
+
+Hyperledger Indy maintains a list of **Common Vulnerabilities and Exposures
+(CVE)** and uses GitHub as its **CVE numbering authority (CNA)** for issuing
+CVEs.
+
+## Embargo List
+
+Hyperledger Indy does **NOT** currently maintain a private embargo list.
+
+If you wish to be added to the embargo list, please email the [Hyperledger
+Foundation security mailing list](mailto:security@lists.hyperledger.org),
+including the project name (Hyperledger Indy) and reason for being added
+to the embargo list. Requests will be assessed by the Hyperledger Indy
+security team in conjunction with the appropriate Hyperledger Staff, and a
+decision will be made to accommodate or not the request.
+
+For more information about embargo lists, please see the [Embargo List section
+of the Hyperledger Security
+Policy](https://toc.hyperledger.org/governing-documents/security.html#embargo-list).
+
+## (GitHub) Security Advisories
+
+Hyperledger Indy uses GitHub Security Advisories to manage the public
+disclosure of security vulnerabilities.
+
+## Private Patch Deployment Infrastructure
+
+In creating patches and new releases that address security vulnerabilities,
+Hyperledger Indy **MAY** use the private development features of GitHub for
+security vulnerabilities. GitHub has [extensive
+documentation](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories)
+about these features.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,12 +55,12 @@ contributors have agreed to follow.
 
 The current Hyperledger Indy security team is:
 
-| Name             | Email ID                 | Discord ID      | Area/Specialty         |
-| ---------------- | ------------------------ | --------------- | ---------------------- |
-| Stephen Curran   | swcurran@cloudcompass.ca | swcurran        |              |
-| Wade Barnes      | wade@neoterictech.ca     | WadeBarnes      | Security, Operations   |
-| Sam Curren       | sam@indicio.tech         | TelegramSam     | Security               |
-| Andrew Whitehead | cywolf@gmail.com         | andrewwhitehead | Cryptography, Security |
+| Name           | Email ID                          | Discord ID    | Area/Specialty       |
+| -------------- | --------------------------------- | ------------- | -------------------- |
+| Stephen Curran | swcurran@cloudcompass.ca          | swcurran      |                      |
+| Wade Barnes    | wade@neoterictech.ca              | WadeBarnes    | Security, Operations |
+| Sam Curren     | sam@indicio.tech                  | TelegramSam   | Security             |
+| Renata Toktar  | renata.toktar@dsr-corporation.com | Renata.toktar | Security             |
 
 The security team for Hyperledger Indy must include at least three Indy
 Maintainers that agree to carry out the following duties and responsibilities.

--- a/TSC.md
+++ b/TSC.md
@@ -1,0 +1,95 @@
+# Hyperledger Indy Technical Steering Committee (TSC)
+
+This file is referenced by the Hyperledger Indy Project Charter and **MUST** contain:
+
+- The list of active TSC Members
+- The duties of the TSC Members, including in those duties the process for updating those duties
+- The process to add and remove TSC Members from active status
+
+Changes to this file **MUST** be made according to the guidance in this file, and in the Hyperledger Indy Project Charter.
+
+## Active TSC Members
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| GitHub ID             | Name           | Email                             | Company Affiliation |
+| --------------------- | -------------- | --------------------------------- | ------------------- |
+| swcurran              | Stephen Curran | swcurran@cloudcompass.ca          | BC Gov              |
+| TelegramSam           | Sam Curren     | sam@inbdicio.tech                 | Indicio PBC         |
+| reflectivedevelopment | Kim Ebert      | kim@indicio.tech                  | Indicio PBC         |
+| WadeBarnes            | Wade Barnes    | wade@neoterictech.ca              | BC Gov              |
+| Toktar                | Renata Toktar  | renata.toktar@dsr-corporation.com | DSR Corporation     |
+| lynnbendixsen         | Lynn Bendixsen | lynn@indicio.tech                 | Indicio PBC         |
+| cjhowland             | Char Howland   | char@indicio.tech                 | Indicio PBC         |
+
+## Emeritus TSC Members
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+## The Duties of a TSC Member
+
+TSC are expected to perform the following duties for the Hyperledger Indy project.
+
+- Attend the meetings of the TSC.
+  - Meetings of the TSC will generally be held during the weekly Indy Working Group calls.
+  - From time to time, special meetings of the TSC Members may be called.
+- Discuss issues about the Governance of the project, guided by the project's Charter, including the documented roles of TSC Members, Maintainers and Contributors.
+- Vote on any issues raised about the project in line with the project's Charter.
+- Discuss and vote on any issues/disputes about the projects escalated by the project's Maintainers or Contributors.
+- When moved, make changes to the project's Charter is permitted by the Charter.
+- Contribute to the Hyperledger Indy Project's Quarterly and Annual Report.
+
+The duties of the TSC Members may be updated through a PR to this file that is voted on by the TSC and merged by a Maintainer of this repository.
+Maintainers of this repository are obligated to handle PRs to this file as guided by the TSC.
+
+## Becoming a TSC Member
+
+The following steps occur in becoming a TSC member, roughly in order.
+
+- The proposed TSC Member establishes their reputation in the Hyperledger Indy Project.
+- A PR is created to update this file to add the proposed TSC to the list of active TSC Members.
+- The PR is authored by an existing TSC Member or has a comment on the PR from an existing TSC Member supporting the proposal.
+- The PR is authored by the proposed TSC Member or has a comment on the PR from the proposed TSC Member confirming their interest in being a TSC Member.
+  - The PR or comment from the proposed TSC Member must include their
+    willingness to be a long-term (more than 6 month) TSC Member.
+- Once the PR and necessary comments have been received, an approval timeframe begins.
+- The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
+- The PR is merged and the proposed TSC Member becomes a TSC Member if either:
+  - Two weeks have passed since at least three (3) TSC Members have approved the PR or have added an comment expressing approval of the PR, OR
+  - An absolute majority of TSC Members have approved the PR or have added an comment expressing approval of the PR.
+- If the PR does not get the requisite PR approvals or comments expressing approval of the PR, it may be closed.
+
+TSC membership itself does not confer repository Maintainer status -- that is a separate process.
+Typically, TSC members will also be Maintainers, but the processes are independent of one another.
+
+## Removing TSC Members
+
+Being a TSC Member is not a status symbol or a title to be carried
+indefinitely. It will occasionally be necessary and appropriate to move a
+TSC Member to emeritus status. This can occur in the following situations:
+
+- Resignation of a TSC Member.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be an extended period of not showing up to TSC Meetings, or participating in TSC discussions at Meetings or in TSC online forums.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other circumstances at the discretion of the other TSC Members.
+
+The process to move a TSC Member from active to emeritus status is comparable to the process for adding a TSC Member, outlined above. In the case of voluntary
+resignation, the Pull Request can be merged following a TSC Member PR approval or approval comment. If the removal is for any other reason, the following steps **SHOULD** be followed:
+
+- A PR is created to update this file to move the TSC Member to the list of emeritus TSC Members.
+- The PR is authored by, or has a comment supporting the proposal from, an existing TSC Member or Hyperledger GitHub organization administrator.
+- Once the PR and necessary comments have been received, the approval timeframe begins.
+- The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
+- The PR is merged and the TSC Members transitions to TSC Members emeritus if:
+  - The PR is approved or an approval comment added by the TSC Members to be transitioned, OR
+  - Two weeks have passed since at least three (3) TSC Member PR approvals or approval comments have been recorded, OR
+  - An absolute majority of TSC Members have approved the PR or added an approval comment.
+- If the PR does not get the requisite PR approvals, it may be closed.
+
+Returning to active status from emeritus status uses the same steps as adding a
+new TSC Member.


### PR DESCRIPTION
Initial files in the repo, including the SECURITY file and the TSC files, both of which call out specific community members for roles on the project.
